### PR TITLE
Update ChirpStack migration for NMS v8.3.13

### DIFF
--- a/src/chirpstack/devices.ts
+++ b/src/chirpstack/devices.ts
@@ -248,20 +248,23 @@ async function translate(
   const dev: LoriotDevice = {
     title: chirpstackDevice.name ? chirpstackDevice.name.toString() : chirpstackDevice.devEui?.toUpperCase(),
     deveui: chirpstackDevice.devEui?.toUpperCase(),
+    description: chirpstackDevice.description ? String(chirpstackDevice.description) : '',
+    L2Version: lorawan,
     devclass: deviceProfile.supportsClassC ? eDeviceClass.C : eDeviceClass.A,
-    devVersion: lorawan.minor == 0 ? eDeviceVersion.v10 : eDeviceVersion.v11,
     devActivation: deviceProfile.supportsOtaa ? eDeviceActivation.OTAA : eDeviceActivation.ABP,
     devaddr: activation?.devAddr?.toUpperCase(),
-    appeui: chirpstackDevice.joinEui?.toUpperCase(),
+    joineui: chirpstackDevice.joinEui?.toUpperCase(),
     appkey: keys?.nwkKey, // Network root key (128 bit). Note: For LoRaWAN 1.0.x, use this field for the LoRaWAN 1.0.x 'AppKey`!
     nwkskey: activation?.nwkSEncKey?.toUpperCase(),
     appskey: activation?.appSKey?.toUpperCase(),
     canSendADR: true,
     rxw: 1, // Not configurable on ChirpStack
-    rx1Delay: 1,
-    seqno: 0, // TODO
-    seqdn: 0, // TODO
+    rx1Delay: deviceProfile?.rx1Delay == 0 ? 1 : Number(deviceProfile.rx1Delay),
+    seqno: activation?.fCntUp ?? 0,
+    seqdn: activation?.nFCntDown ?? 0,
     seqq: 0,
+    flushDnQueueOnJoin: deviceProfile?.flushQueueOnActivate ?? false,
+    seqrelax: chirpstackDevice.skipFcntCheck ?? false
   };
 
   return dev;

--- a/src/chirpstack/integrations.ts
+++ b/src/chirpstack/integrations.ts
@@ -27,9 +27,15 @@ async function getHttpIntegration(channel: ApplicationServiceClient, apiToken: s
     const req: GetHttpIntegrationRequest = new GetHttpIntegrationRequest();
     req.setApplicationId(appId);
 
-    channel.getHttpIntegration(req, metadata, (err, resp?: GetHttpIntegrationResponse) => {
+    channel.getHttpIntegration(req, metadata, (err:any, resp?: GetHttpIntegrationResponse) => {
       if (err) {
-        reject(err);
+        // If integration doesn't exist (NOT_FOUND error), just resolve as undefined
+        if (err.code === 5) { // 5 = NOT_FOUND
+          console.log(`HTTP integration not found for application ${appId}, skipping...`);
+          resolve(undefined);
+        } else {
+          reject(err);
+        }
       } else if (!resp) {
         reject(new Error(`grpc response undefined`));
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,16 +13,22 @@ import { LoriotNetwork, cleanNetworks, importNetworks } from './loriot/networks'
     // (1) LOAD RESOURCES
     var applications: LoriotApplication[] = [];
     var networks: LoriotNetwork[] = [];
+    const migrateGateways = process.env.MIGRATE_GATEWAYS !== undefined ? process.env.MIGRATE_GATEWAYS === 'true' : true;
+    
     if (process.env.CHIRPSTACK_URL && process.env.CHIRPSTACK_API_TOKEN && process.env.CHIRPSTACK_TENANT_ID) {
       // Load ChirpStack applications, integrations and devices
       applications = await loadChirpstackApplications(process.env.CHIRPSTACK_URL, process.env.CHIRPSTACK_API_TOKEN, process.env.CHIRPSTACK_TENANT_ID);
       // Load ChirpStack networks and gateways
-      networks = [await loadChirpstackGateways(process.env.CHIRPSTACK_URL, process.env.CHIRPSTACK_API_TOKEN, process.env.CHIRPSTACK_TENANT_ID)];
+      if (migrateGateways) {
+        networks = [await loadChirpstackGateways(process.env.CHIRPSTACK_URL, process.env.CHIRPSTACK_API_TOKEN, process.env.CHIRPSTACK_TENANT_ID)];
+      }
     } else {
       // Load Kerlink clusters, push configurations and devices
       applications = await loadKerlinkClusters();
       // Load Kerlink networks and gateways
-      networks = await loadKerlinkFleets();
+      if (migrateGateways) {
+        networks = await loadKerlinkFleets();
+      }
     }
 
     // (2) CLEAN RESOURCES ON LORIOT

--- a/src/loriot/applications.ts
+++ b/src/loriot/applications.ts
@@ -104,19 +104,23 @@ export type LoriotDevice = {
   description?: string;
   deveui: string;
   devclass: eDeviceClass;
-  devVersion: eDeviceVersion;
+  L2Version?: lorawanVersion;
+  devVersion?: eDeviceVersion;
   devActivation: eDeviceActivation;
   appkey?: string;
   appeui?: string;
+  joineui?: string;
   devaddr?: string;
   nwkskey?: string;
   appskey?: string;
   canSendADR: boolean;
   rxw: number;
-  rx1Delay: number;
+  rx1Delay?: number;
+  flushDnQueueOnJoin?: boolean;
   seqno: number;
   seqdn: number;
   seqq: number;
+  seqrelax?: boolean;
 };
 
 export type lorawanVersion = { major: number; minor: number; patch: number };


### PR DESCRIPTION
- Added L2Version field to device migration
- Added flushDnQueueOnJoin parameter
- Improved device translation from ChirpStack to LORIOT